### PR TITLE
Disable Wifi Direct in simulation

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,4 @@
 /build
 /captures
 .externalNativeBuild
-TeamCode/release/*
+/TeamCode/release/

--- a/Blocks/src/main/java/com/google/blocks/ftcrobotcontroller/hardware/HardwareItemMap.java
+++ b/Blocks/src/main/java/com/google/blocks/ftcrobotcontroller/hardware/HardwareItemMap.java
@@ -30,7 +30,7 @@ import com.qualcomm.robotcore.hardware.configuration.MotorControllerConfiguratio
 import com.qualcomm.robotcore.hardware.configuration.ReadXMLFileHandler;
 import com.qualcomm.robotcore.hardware.configuration.ServoControllerConfiguration;
 import com.qualcomm.robotcore.util.RobotLog;
-import com.dekaresearch.simulation.SimulationConstants;
+import com.dekaresearch.robotcore.simulation.SimulationConstants;
 import com.dekaresearch.simulation.romi.RomiHardwareFactory;
 
 import org.xmlpull.v1.XmlPullParser;

--- a/FtcCommon/src/main/java/com/qualcomm/ftccommon/FtcEventLoop.java
+++ b/FtcCommon/src/main/java/com/qualcomm/ftccommon/FtcEventLoop.java
@@ -89,7 +89,7 @@ import com.qualcomm.robotcore.robocol.Command;
 import com.qualcomm.robotcore.robocol.TelemetryMessage;
 import com.qualcomm.robotcore.util.RobotLog;
 import com.qualcomm.robotcore.util.SerialNumber;
-import com.dekaresearch.simulation.SimulationConstants;
+import com.dekaresearch.robotcore.simulation.SimulationConstants;
 import com.dekaresearch.simulation.SimulationOpModeListener;
 
 import org.firstinspires.ftc.robotcore.external.ClassFactory;

--- a/FtcCommon/src/main/java/com/qualcomm/ftccommon/FtcEventLoopHandler.java
+++ b/FtcCommon/src/main/java/com/qualcomm/ftccommon/FtcEventLoopHandler.java
@@ -32,7 +32,6 @@ OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE. */
 package com.qualcomm.ftccommon;
 
 import android.content.Context;
-import android.view.KeyEvent;
 
 import androidx.annotation.Nullable;
 
@@ -60,7 +59,7 @@ import com.qualcomm.robotcore.util.ElapsedTime;
 import com.qualcomm.robotcore.util.MovingStatistics;
 import com.qualcomm.robotcore.util.RobotLog;
 import com.qualcomm.robotcore.util.SerialNumber;
-import com.dekaresearch.simulation.SimulationConstants;
+import com.dekaresearch.robotcore.simulation.SimulationConstants;
 import com.dekaresearch.simulation.romi.RomiHardwareFactory;
 
 import org.firstinspires.ftc.robotcore.external.function.Supplier;

--- a/FtcCommon/src/main/java/com/qualcomm/ftccommon/FtcRobotControllerService.java
+++ b/FtcCommon/src/main/java/com/qualcomm/ftccommon/FtcRobotControllerService.java
@@ -61,7 +61,7 @@ import com.qualcomm.robotcore.util.WebServer;
 import com.qualcomm.robotcore.wifi.NetworkConnection;
 import com.qualcomm.robotcore.wifi.NetworkConnectionFactory;
 import com.qualcomm.robotcore.wifi.NetworkType;
-import com.dekaresearch.simulation.SimulationConstants;
+import com.dekaresearch.robotcore.simulation.SimulationConstants;
 import com.dekaresearch.simulation.websockets.SimulationWebSocketClient;
 
 import org.firstinspires.ftc.robotcore.internal.hardware.android.DragonboardIndicatorLED;

--- a/FtcCommon/src/main/java/com/qualcomm/ftccommon/UpdateUI.java
+++ b/FtcCommon/src/main/java/com/qualcomm/ftccommon/UpdateUI.java
@@ -39,7 +39,7 @@ import android.text.Html;
 import android.view.View;
 import android.widget.TextView;
 
-import com.dekaresearch.simulation.SimulationConstants;
+import com.dekaresearch.robotcore.simulation.SimulationConstants;
 import com.dekaresearch.simulation.websockets.SimulationWebSocketClient;
 import com.qualcomm.robotcore.eventloop.EventLoopManager;
 import com.qualcomm.robotcore.eventloop.opmode.OpModeManager;
@@ -57,10 +57,8 @@ import org.firstinspires.ftc.robotcore.external.Telemetry;
 import org.firstinspires.ftc.robotcore.internal.network.DeviceNameListener;
 import org.firstinspires.ftc.robotcore.internal.network.DeviceNameManagerFactory;
 import org.firstinspires.ftc.robotcore.internal.system.AppUtil;
-import org.firstinspires.ftc.robotcore.internal.network.WifiDirectDeviceNameManager;
 import org.firstinspires.ftc.robotcore.internal.network.NetworkStatus;
 import org.firstinspires.ftc.robotcore.internal.network.PeerStatus;
-import org.w3c.dom.Text;
 
 import java.util.Map;
 import java.util.TreeSet;

--- a/FtcCommon/src/main/java/com/qualcomm/ftccommon/configuration/RobotConfigFileManager.java
+++ b/FtcCommon/src/main/java/com/qualcomm/ftccommon/configuration/RobotConfigFileManager.java
@@ -4,7 +4,6 @@
 
 package com.qualcomm.ftccommon.configuration;
 
-import android.annotation.SuppressLint;
 import android.app.Activity;
 import android.content.Context;
 import android.content.SharedPreferences;
@@ -17,7 +16,7 @@ import androidx.annotation.XmlRes;
 import android.view.View;
 import android.widget.TextView;
 
-import com.dekaresearch.simulation.SimulationConstants;
+import com.dekaresearch.robotcore.simulation.SimulationConstants;
 import com.google.gson.reflect.TypeToken;
 import com.qualcomm.ftccommon.CommandList;
 import com.qualcomm.ftccommon.R;

--- a/FtcCommon/src/main/java/com/qualcomm/ftccommon/configuration/RobotConfigFileManager.java
+++ b/FtcCommon/src/main/java/com/qualcomm/ftccommon/configuration/RobotConfigFileManager.java
@@ -251,7 +251,7 @@ public class RobotConfigFileManager {
             {
                 @Override public void run()
                 {
-                    if(SimulationConstants.isSimulation && SimulationConstants.isRomi) {
+                    if(SimulationConstants.isSimulation) {
                         TextView activeFile = (TextView) activity.findViewById(idActiveConfigName);
                         if (activeFile != null) {
                             activeFile.setText("Romi (built in)");

--- a/FtcRobotController/src/main/java/org/firstinspires/ftc/robotcontroller/internal/FtcRobotControllerActivity.java
+++ b/FtcRobotController/src/main/java/org/firstinspires/ftc/robotcontroller/internal/FtcRobotControllerActivity.java
@@ -67,6 +67,7 @@ import android.widget.PopupMenu;
 import android.widget.TextView;
 
 import com.dekaresearch.robotcore.simulation.SimulationConstants;
+import com.dekaresearch.simulation.util.EmulationDetection;
 import com.google.blocks.ftcrobotcontroller.ProgrammingWebHandlers;
 import com.google.blocks.ftcrobotcontroller.runtime.BlocksOpMode;
 import com.qualcomm.ftccommon.ClassManagerFactory;
@@ -517,7 +518,11 @@ public class FtcRobotControllerActivity extends Activity implements OpModeSelect
     if (Device.isRevControlHub() == true) {
       networkType = NetworkType.RCWIRELESSAP;
     } if(SimulationConstants.isSimulation) {
-      networkType = NetworkType.EXTERNALAP;
+      if(EmulationDetection.isBlueStacks()) {
+        networkType = NetworkType.EMULATION_LOOPBACK;
+      } else {
+        networkType = NetworkType.EXTERNALAP;
+      }
     } else {
       networkType = NetworkType.fromString(preferencesHelper.readString(context.getString(R.string.pref_pairing_kind), NetworkType.globalDefaultAsString()));
     }

--- a/FtcRobotController/src/main/java/org/firstinspires/ftc/robotcontroller/internal/FtcRobotControllerActivity.java
+++ b/FtcRobotController/src/main/java/org/firstinspires/ftc/robotcontroller/internal/FtcRobotControllerActivity.java
@@ -516,6 +516,8 @@ public class FtcRobotControllerActivity extends Activity implements OpModeSelect
     // being always runs the wifi direct model.
     if (Device.isRevControlHub() == true) {
       networkType = NetworkType.RCWIRELESSAP;
+    } if(SimulationConstants.isSimulation) {
+      networkType = NetworkType.EXTERNALAP;
     } else {
       networkType = NetworkType.fromString(preferencesHelper.readString(context.getString(R.string.pref_pairing_kind), NetworkType.globalDefaultAsString()));
     }

--- a/FtcRobotController/src/main/java/org/firstinspires/ftc/robotcontroller/internal/FtcRobotControllerActivity.java
+++ b/FtcRobotController/src/main/java/org/firstinspires/ftc/robotcontroller/internal/FtcRobotControllerActivity.java
@@ -41,7 +41,6 @@ import android.content.ServiceConnection;
 import android.content.SharedPreferences;
 import android.content.res.Configuration;
 import android.content.res.Resources;
-import android.graphics.Typeface;
 import android.hardware.usb.UsbDevice;
 import android.hardware.usb.UsbManager;
 import android.net.wifi.WifiManager;
@@ -62,13 +61,12 @@ import android.view.WindowManager;
 import android.webkit.WebView;
 import android.widget.Button;
 import android.widget.ImageButton;
-import android.widget.ImageView;
 import android.widget.LinearLayout;
 import android.widget.LinearLayout.LayoutParams;
 import android.widget.PopupMenu;
 import android.widget.TextView;
 
-import com.dekaresearch.simulation.SimulationConstants;
+import com.dekaresearch.robotcore.simulation.SimulationConstants;
 import com.google.blocks.ftcrobotcontroller.ProgrammingWebHandlers;
 import com.google.blocks.ftcrobotcontroller.runtime.BlocksOpMode;
 import com.qualcomm.ftccommon.ClassManagerFactory;
@@ -95,11 +93,8 @@ import com.qualcomm.robotcore.eventloop.opmode.OpModeRegister;
 import com.qualcomm.robotcore.hardware.Gamepad;
 import com.qualcomm.robotcore.hardware.configuration.LynxConstants;
 import com.qualcomm.robotcore.hardware.configuration.Utility;
-import com.qualcomm.robotcore.robocol.Command;
-import com.qualcomm.robotcore.robocol.TelemetryMessage;
 import com.qualcomm.robotcore.robot.Robot;
 import com.qualcomm.robotcore.robot.RobotState;
-import com.qualcomm.robotcore.util.BatteryChecker;
 import com.qualcomm.robotcore.util.Device;
 import com.qualcomm.robotcore.util.Dimmer;
 import com.qualcomm.robotcore.util.ImmersiveMode;
@@ -114,9 +109,7 @@ import org.firstinspires.ftc.ftccommon.internal.FtcRobotControllerWatchdogServic
 import org.firstinspires.ftc.ftccommon.internal.ProgramAndManageActivity;
 import org.firstinspires.ftc.onbotjava.OnBotJavaHelperImpl;
 import org.firstinspires.ftc.onbotjava.OnBotJavaProgrammingMode;
-import org.firstinspires.ftc.robotcore.external.Event;
 import org.firstinspires.ftc.robotcore.external.Predicate;
-import org.firstinspires.ftc.robotcore.external.Telemetry;
 import org.firstinspires.ftc.robotcore.external.navigation.MotionDetection;
 import org.firstinspires.ftc.robotcore.internal.hardware.android.AndroidBoard;
 import org.firstinspires.ftc.robotcore.internal.network.DeviceNameManagerFactory;
@@ -139,12 +132,9 @@ import org.firstinspires.ftc.robotcore.internal.webserver.RobotControllerWebInfo
 import org.firstinspires.ftc.robotserver.internal.programmingmode.ProgrammingModeManager;
 import org.firstinspires.inspection.RcInspectionActivity;
 
-import java.security.Key;
 import java.util.LinkedList;
 import java.util.List;
-import java.util.Map;
 import java.util.Queue;
-import java.util.TreeSet;
 import java.util.concurrent.ConcurrentLinkedQueue;
 
 @SuppressWarnings("WeakerAccess")

--- a/RobotCore/src/main/java/com/dekaresearch/robotcore/simulation/EmulationLoopbackAssistant.java
+++ b/RobotCore/src/main/java/com/dekaresearch/robotcore/simulation/EmulationLoopbackAssistant.java
@@ -99,7 +99,7 @@ public class EmulationLoopbackAssistant extends NetworkConnection {
 
     @Override
     public String getDeviceName() {
-        return "";
+        return getConnectionOwnerName();
     }
 
     @Override

--- a/RobotCore/src/main/java/com/dekaresearch/robotcore/simulation/EmulationLoopbackAssistant.java
+++ b/RobotCore/src/main/java/com/dekaresearch/robotcore/simulation/EmulationLoopbackAssistant.java
@@ -1,0 +1,134 @@
+package com.dekaresearch.robotcore.simulation;
+
+import android.content.Context;
+
+import com.qualcomm.robotcore.util.Network;
+import com.qualcomm.robotcore.wifi.NetworkConnection;
+import com.qualcomm.robotcore.wifi.NetworkType;
+
+import org.firstinspires.ftc.robotcore.internal.network.ApChannel;
+import org.firstinspires.ftc.robotcore.internal.network.InvalidNetworkSettingException;
+
+import java.net.InetAddress;
+import java.net.UnknownHostException;
+import java.util.ArrayList;
+
+import androidx.annotation.Nullable;
+
+@SuppressWarnings("WeakerAccess")
+public class EmulationLoopbackAssistant extends NetworkConnection {
+
+    private static EmulationLoopbackAssistant emulationLoopbackAssistant = null;
+
+    private EmulationLoopbackAssistant(Context context) {
+        super(context);
+    }
+
+    public synchronized static EmulationLoopbackAssistant getEmulationLoopbackAssistant(Context context) {
+        if (emulationLoopbackAssistant == null) {
+            emulationLoopbackAssistant = new EmulationLoopbackAssistant(context);
+        }
+
+        return emulationLoopbackAssistant;
+    }
+
+    @Override
+    public NetworkType getNetworkType() {
+        return NetworkType.EMULATION_LOOPBACK;
+    }
+
+    @Override
+    public void enable() {
+
+    }
+
+    @Override
+    public void disable() {
+
+    }
+
+    @Override
+    public void discoverPotentialConnections() {
+
+    }
+
+    @Override
+    public void cancelPotentialConnections() {
+
+    }
+
+    @Override
+    public void createConnection() {
+
+    }
+
+    @Override
+    public void connect(String deviceAddress) {
+
+    }
+
+    @Override
+    public void connect(String connectionName, String connectionPassword) {
+
+    }
+
+    @Override
+    public void detectWifiReset() {
+
+    }
+
+    @Override
+    public InetAddress getConnectionOwnerAddress() {
+        return Network.getLoopbackAddress();
+    }
+
+    @Override
+    public String getConnectionOwnerName() {
+        return "";
+    }
+
+    @Override
+    public String getConnectionOwnerMacAddress() {
+        return "";
+    }
+
+    @Override
+    public boolean isConnected() {
+        return true;
+    }
+
+    @Override
+    public String getDeviceName() {
+        return "";
+    }
+
+    @Override
+    public String getInfo() {
+        return "";
+    }
+
+    @Override
+    public String getFailureReason() {
+        return "";
+    }
+
+    @Override
+    public String getPassphrase() {
+        return "";
+    }
+
+    @Override
+    public ConnectStatus getConnectStatus() {
+        return ConnectStatus.CONNECTED;
+    }
+
+    @Override
+    public void onWaitForConnection() {
+
+    }
+
+    @Override
+    public void setNetworkSettings(@Nullable String deviceName, @Nullable String password, @Nullable ApChannel channel) throws InvalidNetworkSettingException {
+
+    }
+}

--- a/RobotCore/src/main/java/com/dekaresearch/robotcore/simulation/ExternalApAssistant.java
+++ b/RobotCore/src/main/java/com/dekaresearch/robotcore/simulation/ExternalApAssistant.java
@@ -1,0 +1,159 @@
+package com.dekaresearch.robotcore.simulation;
+
+import android.annotation.SuppressLint;
+import android.content.Context;
+import android.net.ConnectivityManager;
+import android.net.wifi.SupplicantState;
+import android.net.wifi.WifiInfo;
+import android.net.wifi.WifiManager;
+
+import com.qualcomm.robotcore.util.Network;
+import com.qualcomm.robotcore.util.RobotLog;
+import com.qualcomm.robotcore.wifi.NetworkConnection;
+import com.qualcomm.robotcore.wifi.NetworkType;
+
+import org.firstinspires.ftc.robotcore.internal.network.ApChannel;
+import org.firstinspires.ftc.robotcore.internal.network.InvalidNetworkSettingException;
+import org.firstinspires.ftc.robotcore.internal.network.WifiUtil;
+import org.firstinspires.ftc.robotcore.internal.system.AppUtil;
+
+import java.net.InetAddress;
+import java.util.ArrayList;
+
+import androidx.annotation.Nullable;
+
+@SuppressWarnings("WeakerAccess")
+public class ExternalApAssistant extends NetworkConnection {
+
+    private static ExternalApAssistant externalApAssistant = null;
+
+    @SuppressLint("WifiManagerLeak")
+    protected final WifiManager wifiManager = (WifiManager) AppUtil.getDefContext().getSystemService(Context.WIFI_SERVICE);
+
+    private ExternalApAssistant(Context context) {
+        super(context);
+    }
+
+    public synchronized static ExternalApAssistant getExternalApAssistant(Context context) {
+        if (externalApAssistant == null) {
+            externalApAssistant = new ExternalApAssistant(context);
+        }
+
+        return externalApAssistant;
+    }
+
+    @Override
+    public NetworkType getNetworkType() {
+        return NetworkType.EXTERNALAP;
+    }
+
+    @Override
+    public void enable() {
+
+    }
+
+    @Override
+    public void disable() {
+
+    }
+
+    @Override
+    public void discoverPotentialConnections() {
+
+    }
+
+    @Override
+    public void cancelPotentialConnections() {
+
+    }
+
+    @Override
+    public void createConnection() {
+
+    }
+
+    @Override
+    public void connect(String deviceAddress) {
+
+    }
+
+    @Override
+    public void connect(String connectionName, String connectionPassword) {
+
+    }
+
+    @Override
+    public void detectWifiReset() {
+
+    }
+
+    @Override
+    public InetAddress getConnectionOwnerAddress() {
+        ArrayList<InetAddress> localIpAddresses = Network.getLocalIpAddresses();
+        localIpAddresses = Network.removeLoopbackAddresses(localIpAddresses);
+        localIpAddresses = Network.removeIPv6Addresses(localIpAddresses);
+
+        // Safety
+        if(localIpAddresses.size() == 0) {
+            return Network.getLoopbackAddress();
+        }
+
+        return localIpAddresses.get(0);
+    }
+
+    @Override
+    public String getConnectionOwnerName() {
+        return WifiUtil.getConnectedSsid();
+    }
+
+    @Override
+    public String getConnectionOwnerMacAddress() {
+        return "";
+    }
+
+    @Override
+    public boolean isConnected() {
+        if (wifiManager.isWifiEnabled()) {
+            WifiInfo wifiInfo = wifiManager.getConnectionInfo();
+
+            boolean acquiredIp = !getConnectionOwnerAddress().equals(Network.getLoopbackAddress());
+            return wifiInfo.getNetworkId() != -1 && acquiredIp;
+        }
+        return false;
+    }
+
+    @Override
+    public String getDeviceName() {
+        return getConnectionOwnerName();
+    }
+
+    @Override
+    public String getInfo() {
+        return "";
+    }
+
+    @Override
+    public String getFailureReason() {
+        return "";
+    }
+
+    @Override
+    public String getPassphrase() {
+        return "";
+    }
+
+    @Override
+    public ConnectStatus getConnectStatus() {
+        return ConnectStatus.CONNECTED;
+    }
+
+    @Override
+    public void onWaitForConnection() {
+
+    }
+
+    @Override
+    public void setNetworkSettings(@Nullable String deviceName, @Nullable String password, @Nullable ApChannel channel) throws InvalidNetworkSettingException {
+
+    }
+}

--- a/RobotCore/src/main/java/com/dekaresearch/robotcore/simulation/SimulationConstants.java
+++ b/RobotCore/src/main/java/com/dekaresearch/robotcore/simulation/SimulationConstants.java
@@ -6,5 +6,4 @@ public class SimulationConstants {
      * Change this to enable or disable all simulation related code
      */
     public static boolean isSimulation = true;
-    public static boolean isRomi = true;
 }

--- a/RobotCore/src/main/java/com/dekaresearch/robotcore/simulation/SimulationConstants.java
+++ b/RobotCore/src/main/java/com/dekaresearch/robotcore/simulation/SimulationConstants.java
@@ -1,4 +1,4 @@
-package com.dekaresearch.simulation;
+package com.dekaresearch.robotcore.simulation;
 
 public class SimulationConstants {
 

--- a/RobotCore/src/main/java/com/qualcomm/robotcore/wifi/NetworkConnectionFactory.java
+++ b/RobotCore/src/main/java/com/qualcomm/robotcore/wifi/NetworkConnectionFactory.java
@@ -32,6 +32,8 @@ package com.qualcomm.robotcore.wifi;
 
 import android.content.Context;
 
+import com.dekaresearch.robotcore.simulation.EmulationLoopbackAssistant;
+import com.dekaresearch.robotcore.simulation.ExternalApAssistant;
 import com.qualcomm.robotcore.util.RobotLog;
 
 public class NetworkConnectionFactory {
@@ -51,6 +53,10 @@ public static NetworkConnection getNetworkConnection(NetworkType type, Context c
         return DriverStationAccessPointAssistant.getDriverStationAccessPointAssistant(context);
       case RCWIRELESSAP:
         return RobotControllerAccessPointAssistant.getRobotControllerAccessPointAssistant(context);
+      case EXTERNALAP:
+        return ExternalApAssistant.getExternalApAssistant(context);
+      case EMULATION_LOOPBACK:
+        return EmulationLoopbackAssistant.getEmulationLoopbackAssistant(context);
       default:
         return null;
     }

--- a/RobotCore/src/main/java/com/qualcomm/robotcore/wifi/NetworkType.java
+++ b/RobotCore/src/main/java/com/qualcomm/robotcore/wifi/NetworkType.java
@@ -38,7 +38,9 @@ public enum NetworkType
     SOFTAP,
     WIRELESSAP,
     RCWIRELESSAP,
-    UNKNOWN_NETWORK_TYPE;
+    UNKNOWN_NETWORK_TYPE,
+    EXTERNALAP, // Simulation
+    EMULATION_LOOPBACK; // Simulation
 
     public static @NonNull NetworkType fromString(String type) {
       try {

--- a/RobotServer/src/main/java/org/firstinspires/ftc/robotserver/internal/webserver/CoreRobotWebServer.java
+++ b/RobotServer/src/main/java/org/firstinspires/ftc/robotserver/internal/webserver/CoreRobotWebServer.java
@@ -30,6 +30,7 @@
 
 package org.firstinspires.ftc.robotserver.internal.webserver;
 
+import com.dekaresearch.robotcore.simulation.SimulationConstants;
 import com.qualcomm.robotcore.util.RobotLog;
 import com.qualcomm.robotcore.util.WebHandlerManager;
 import com.qualcomm.robotcore.util.WebServer;
@@ -154,6 +155,11 @@ public class CoreRobotWebServer implements WebServer {
                     else
                     {
                         networkName = null;
+                    }
+                    if(SimulationConstants.isSimulation) {
+                        if(networkConnection.getNetworkType() == NetworkType.EXTERNALAP) {
+                            networkName = networkConnection.getConnectionOwnerName();
+                        }
                     }
                     connectionOwnerAddress = networkConnection.getConnectionOwnerAddress();
 

--- a/Simulation/src/main/java/com/dekaresearch/simulation/util/EmulationDetection.java
+++ b/Simulation/src/main/java/com/dekaresearch/simulation/util/EmulationDetection.java
@@ -1,0 +1,20 @@
+package com.dekaresearch.simulation.util;
+
+import android.os.Environment;
+
+import java.io.File;
+
+public class EmulationDetection {
+    public static boolean isBlueStacks() {
+        String path = Environment.getExternalStorageDirectory().toString();
+        File directory = new File(path);
+        File[] files = directory.listFiles();
+        if(files == null) return false;
+        for (File file : files) {
+            if (file.getName().contains("windows")) {
+                return true;
+            }
+        }
+        return false;
+    }
+}

--- a/Simulation/src/main/java/com/dekaresearch/simulation/websockets/SimulationWebSocketClient.java
+++ b/Simulation/src/main/java/com/dekaresearch/simulation/websockets/SimulationWebSocketClient.java
@@ -43,7 +43,7 @@ public class SimulationWebSocketClient {
     }
 
     private SimulationWebSocketClient() {
-        setServer("192.168.49.2", 3300);
+        setServer("10.0.0.2", 3300);
     }
 
     public void setServer(URI serverUri) {


### PR DESCRIPTION
If simulation is enabled, an external wireless AP will be used if it is a real device. If it is an emulated device, loopback will be used instead.